### PR TITLE
Support batch mode in MigrationBench's final eval.

### DIFF
--- a/src/migration_bench/eval/test_final_eval.py
+++ b/src/migration_bench/eval/test_final_eval.py
@@ -100,11 +100,20 @@ class TestFinalEval(unittest.TestCase):
             ),
         )
     )
-    def test_run_eval(self, url, git_diff_file, kwargs, expected_success):
-        """Unit test for `run_eval`."""
-        self.assertEqual(
-            final_eval.run_eval(url, git_diff_file, **kwargs), expected_success
-        )
+    def test_run_batch_eval(self, url, git_diff_file, kwargs, expected_success):
+        """Unit test for `run_batch_eval`."""
+        git_diff_content = utils.load_file(git_diff_file or "")
+
+        predictions = [
+            {
+                final_eval.KEY_GITHUB_URL: url,
+                final_eval.KEY_GIT_DIFF_CONTENT: git_diff_content,
+            },
+        ]
+        count = final_eval.run_batch_eval(predictions, **kwargs)
+
+        self.assertIsInstance(count, int)
+        self.assertEqual(bool(count), expected_success)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
It supports eval for a single repo, by providing its Github url & a Git diff file.

## Changes
It adds support for eval in **batch** mode, by providing a predictions file (`.json`) with a list of repos to run final eval.

For each repo, it contains:
1. The Github url
2. Git diff with 2 options:
    1. `git_diff`: The git diff content
    2. `git_diff_file`: The git diff file similar to the single job mode



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
