### PR TITLE
fix: run eval within the tempfile context manager

### DIFF
--- a/src/migration_bench/eval/final_eval.py
+++ b/src/migration_bench/eval/final_eval.py
@@ -284,6 +284,7 @@ def _process_single_prediction(pred_data):
                 temp_file = os.path.join(temp_dir, "git.diff")
                 utils.export_file(temp_file, git_diff)
                 git_diff_file = temp_file
+                return run_eval(github_url, git_diff_file, migrated_root_dir, **kwargs)
 
     return run_eval(github_url, git_diff_file, migrated_root_dir, **kwargs)
 


### PR DESCRIPTION
*Description of changes:* Fix a bug introduced in https://github.com/amazon-science/MigrationBench/pull/12, which runs eval outside the tempfile context manager. This causes errors when git diff content is directly provided instead of the git diff name. Both paths should work now after this fix. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
