### PR TITLE
fix(parse_repo): return 3-tuple consistently from same_repo_test_files

### DIFF
--- a/src/migration_bench/lang/java/eval/parse_repo.py
+++ b/src/migration_bench/lang/java/eval/parse_repo.py
@@ -75,7 +75,7 @@ def same_repo_test_files(
     files = sorted(lhs_tests.keys())
     if files != sorted(rhs_tests.keys()):
         logging.warning("File mismatch: `%s` => `%s`.", files, sorted(rhs_tests.keys()))
-        return False, len(lhs_tests)
+        return False, len(lhs_tests), None
 
     issues = []
     test_issues = []


### PR DESCRIPTION
*Description of changes:*

### Issue
The filename-mismatch path returned a 2-tuple while the other three exit points returned 3-tuples, causing positional indexing in downstream callers (e.g. result[-1] or result[2]) to silently flip from a boolean to an int. This made @Test-equivalence checks falsely succeed when an agent renamed or replaced test files.

### Fix
Pad the 2-tuple to match the existing (success, count, test_match) shape; None for the third slot signals "comparison not attempted," consistent with the file-count-mismatch path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
