### PR TITLE
fix(parse_file): handle EnumDeclaration and AnnotationDeclaration in get_classes_and_methods

### DIFF
--- a/src/migration_bench/lang/java/eval/parse_file.py
+++ b/src/migration_bench/lang/java/eval/parse_file.py
@@ -7,10 +7,10 @@ import javalang
 from migration_bench.common import utils
 
 
-CLASS = "class"
-INTERFACE = "interface"
-ENUM = "enum"
 ANNOTATION = "annotation"
+CLASS = "class"
+ENUM = "enum"
+INTERFACE = "interface"
 METHOD = "method"
 
 METHOD_ANNOTATION_TEST = "Test"

--- a/src/migration_bench/lang/java/eval/parse_file.py
+++ b/src/migration_bench/lang/java/eval/parse_file.py
@@ -9,6 +9,8 @@ from migration_bench.common import utils
 
 CLASS = "class"
 INTERFACE = "interface"
+ENUM = "enum"
+ANNOTATION = "annotation"
 METHOD = "method"
 
 METHOD_ANNOTATION_TEST = "Test"
@@ -34,6 +36,12 @@ def get_classes_and_methods(filename: str, content: str = None, add_line: bool =
         elif isinstance(node, javalang.tree.InterfaceDeclaration):
             current_class = node.name
             nodes.append((INTERFACE, current_class))
+        elif isinstance(node, javalang.tree.EnumDeclaration):
+            current_class = node.name
+            nodes.append((ENUM, current_class))
+        elif isinstance(node, javalang.tree.AnnotationDeclaration):
+            current_class = node.name
+            nodes.append((ANNOTATION, current_class))
         elif isinstance(node, javalang.tree.MethodDeclaration):
             if not current_class:
                 raise ValueError(

--- a/src/migration_bench/lang/java/eval/test_parse_file.py
+++ b/src/migration_bench/lang/java/eval/test_parse_file.py
@@ -19,6 +19,8 @@ FILE_00_LINE_NO_CHANGE = "./testdata/AstParser.java"
 
 FILE_01 = "../native/src/main/java/qct/XmlBeautifier.java"
 FILE_02 = "./testdata/LabelManager.java"
+FILE_03 = "./testdata/Status.java"
+FILE_04 = "./testdata/Marker.java"
 
 
 class TestParseFile(unittest.TestCase):
@@ -76,6 +78,26 @@ class TestParseFile(unittest.TestCase):
                     ("interface", "LabelManager"),
                     ("method", ("setLocale", False)),
                     ("method", ("get", False)),
+                ),
+            ),
+            # Top-level enum with constants overriding an abstract method.
+            # Pre-fix: raised "Unable to find out class for method `describe`".
+            (
+                FILE_03,
+                {},
+                (
+                    ("enum", "Status"),
+                    ("method", ("describe", False)),
+                    ("method", ("describe", False)),
+                    ("method", ("describe", False)),
+                ),
+            ),
+            # Top-level annotation declaration.
+            (
+                FILE_04,
+                {},
+                (
+                    ("annotation", "Marker"),
                 ),
             ),
         )

--- a/src/migration_bench/lang/java/eval/testdata/Marker.java
+++ b/src/migration_bench/lang/java/eval/testdata/Marker.java
@@ -1,0 +1,10 @@
+package com.example;
+
+/**
+ * Top-level annotation declaration with a method element. Previously crashed
+ * parse_file.get_classes_and_methods because AnnotationDeclaration was not
+ * handled.
+ */
+public @interface Marker {
+    String value() default "";
+}

--- a/src/migration_bench/lang/java/eval/testdata/Status.java
+++ b/src/migration_bench/lang/java/eval/testdata/Status.java
@@ -1,0 +1,23 @@
+package com.example;
+
+/**
+ * Top-level enum with constants whose bodies override an abstract method.
+ * This shape (seen in repos like thomasmueller/tinyStats) previously crashed
+ * parse_file.get_classes_and_methods because EnumDeclaration was not handled.
+ */
+public enum Status {
+    OK {
+        @Override
+        public String describe() {
+            return "ok";
+        }
+    },
+    BAD {
+        @Override
+        public String describe() {
+            return "bad";
+        }
+    };
+
+    public abstract String describe();
+}


### PR DESCRIPTION
### Summary

`parse_file.get_classes_and_methods` only sets `current_class` when it encounters `ClassDeclaration` or `InterfaceDeclaration`. Top-level enums and annotations fall through, so when the AST traversal reaches a method nested inside an enum constant's anonymous body, `current_class is None` and the function raises:

```
ValueError: Unable to find out class for method <name>
```

This crashes `same_classes_and_methods` (and any caller of `get_classes_and_methods`) on otherwise-valid Java sources.

### Repos affected

Three repos in `AmazonScience/migration-bench-java-full` deterministically hit this crash during reward evaluation (8/8 rollouts each in one training step):

- `thomasmueller/tinyStats` — top-level enum with abstract method overridden in each constant's anonymous body (the canonical reproducer).
- `justauth/JustAuth` — same shape, different method name (`authorize`).
- `orphan-oss/ognl` — same shape, different method name (`getValue`).

### Fix

Add `EnumDeclaration` and `AnnotationDeclaration` to the dispatch in `get_classes_and_methods`, alongside two new module-level constants `ENUM` and `ANNOTATION` (mirroring the existing `CLASS` / `INTERFACE` pair):

```python
elif isinstance(node, javalang.tree.EnumDeclaration):
    current_class = node.name
    nodes.append((ENUM, current_class))
elif isinstance(node, javalang.tree.AnnotationDeclaration):
    current_class = node.name
    nodes.append((ANNOTATION, current_class))
```

`same_classes_and_methods` compares the same file pre/post-migration, so the new tuple types align on both sides — no change required there.

### Tests

Added two fixtures and two parametrized cases covering the new shapes:

- `testdata/Status.java` — top-level enum with constants overriding an abstract
  method (matches the `tinyStats` shape that triggered the original crash).
- `testdata/Marker.java` — top-level `@interface` with a method element.

The new cases are appended to the existing `@parameterized.expand` block on `test_get_classes_and_methods` and assert the expected tuple sequences:

- `Status.java` → `(("enum", "Status"), ("method", ("describe", False)), ...)`
- `Marker.java` → `(("annotation", "Marker"),)`

Local run: `python -m unittest migration_bench.lang.java.eval.test_parse_file -v` — 19/19 pass (5 pre-existing `get_classes_and_methods` cases + 2 new + 12 unrelated).

### End-to-end validation

Beyond unit tests, validated using a vLLM-served Qwen3-Coder-30B as the migration agent:

- `thomasmueller/tinyStats` rollout: pre-fix the reward function raised`ValueError: Unable to find out class for method describe` and the rollout errored out. Post-fix, the same repo runs end-to-end and produces a numeric reward (`reward=1.0`, build + test equivalence both pass) — the agent's full migration was successfully scored for the first time.
- The other two enum/annotation repos (`JustAuth`, `ognl`) no longer crash; they now flow through the reward function normally and either succeed or fail on legitimate migration criteria.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
